### PR TITLE
Update README with Python version note

### DIFF
--- a/PosturaZen/README.md
+++ b/PosturaZen/README.md
@@ -3,8 +3,16 @@
 Sistema de detección de postura utilizando MediaPipe y OpenCV.
 
 ## Requisitos
-- Python 3.10+
+- Python 3.10 a 3.12
 - Webcam disponible
+
+> **Nota sobre Python 3.13**
+>
+> Actualmente `mediapipe`, la dependencia principal del proyecto, no
+> distribuye ruedas para Python 3.13. Para evitar errores al instalar los
+> requisitos, se recomienda utilizar Python 3.10, 3.11 o 3.12. Cuando el
+> paquete proporcione soporte oficial para Python 3.13 se actualizará la
+> compatibilidad de PosturaZen.
 
 ## Instalación
 ```bash


### PR DESCRIPTION
## Summary
- specify supported Python versions in the PosturaZen README
- add note about mediapipe's lack of Python 3.13 wheels

## Testing
- `python3 -m py_compile PosturaZen/main.py PosturaZen/calibracion/*.py PosturaZen/deteccion/*.py PosturaZen/utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688397b878908325ab68d3e766f63c1d