### PR TITLE
Handle malformed posture config

### DIFF
--- a/PosturaZen/main.py
+++ b/PosturaZen/main.py
@@ -2,18 +2,16 @@
 
 import os
 
-from PosturaZen.calibracion.calibrador import Calibrador, PosturaBase
 from PosturaZen.deteccion.detector import Detector, cargar_postura
 
 BASE_PATH = os.path.join(os.path.dirname(__file__), "postura_base.json")
 
 
 def main() -> None:
-    if not os.path.exists(BASE_PATH):
-        calibrador = Calibrador()
-        postura_base = calibrador.calibrar()
-    else:
-        postura_base = cargar_postura(BASE_PATH)
+    """Ejecuta la detección de postura asegurando calibración válida."""
+
+    # Cargar la calibración o generar una de prueba si es necesario
+    postura_base = cargar_postura(BASE_PATH)
 
     no_molestar = os.environ.get("POSTURAZEN_SILENCIO", "0") == "1"
     detector = Detector(postura_base, no_molestar=no_molestar)


### PR DESCRIPTION
## Summary
- parse nested calibration JSON structures in `PosturaBase.from_dict`
- add robust posture loader that rebuilds a test config when missing or invalid
- simplify `main` to always load posture through this function

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883a49f47d08325aed34d6dfc59e541