### PR TITLE
Update page to load mediapipe dynamically

### DIFF
--- a/posturazen-web/frontend/src/routes/+page.svelte
+++ b/posturazen-web/frontend/src/routes/+page.svelte
@@ -1,7 +1,10 @@
+<script context="module" lang="ts">
+export const ssr = false;
+</script>
+
 <script lang="ts">
 import { onMount } from 'svelte';
-import { Pose } from '@mediapipe/pose';
-import { calibrate, type CalibrationData } from '$lib/pose/calibrate';
+import { calibrate } from '$lib/pose/calibrate';
 import { PostureDetector } from '$lib/pose/detector';
 
 let video: HTMLVideoElement;
@@ -10,18 +13,24 @@ let detector: PostureDetector | null = null;
 let calibrated = false;
 
 onMount(async () => {
-    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
-    video.srcObject = stream;
-    await video.play();
+    const posePkg = await import('@mediapipe/pose');
+    const { Pose } = posePkg;
+    const camPkg = await import('@mediapipe/camera_utils');
+    const { Camera } = camPkg;
 
-    const pose = new Pose({ locateFile: (f) => `https://cdn.jsdelivr.net/npm/@mediapipe/pose/${f}` });
+    const pose = new Pose({
+        locateFile: (file: string) => `https://cdn.jsdelivr.net/npm/@mediapipe/pose/${file}`
+    });
     pose.setOptions({ modelComplexity: 0, selfieMode: true });
+
+    const camera = new Camera(video, { onFrame: async () => {} });
+    await camera.start();
 
     const calib = await calibrate(pose, video);
     calibrated = true;
     message = 'Postura calibrada. Monitoreando...';
     detector = new PostureDetector(pose, calib);
-    detector.onAlert(() => speak('Por favor, corrige tu postura')); 
+    detector.onAlert(() => speak('Por favor, corrige tu postura'));
     detector.start(video);
 });
 


### PR DESCRIPTION
## Summary
- disable SSR on posture monitoring route
- dynamically load `@mediapipe/pose` and `@mediapipe/camera_utils`
- initialise BlazePose with CDN files
- start `Camera` after module load

## Testing
- `npm run check` *(fails: svelte-check found 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883c164f0b88325a54e002d7a89c4b0