### PR TITLE
Add real-time HRV estimator

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,52 @@
+"""Example usage of the HRVEstimator using MediaPipe Face Mesh."""
+
+import cv2
+import mediapipe as mp
+
+from modules.hrv_rppg import HRVEstimator
+
+
+def main() -> None:
+    cap = cv2.VideoCapture(0)
+    face_mesh = mp.solutions.face_mesh.FaceMesh(static_image_mode=False, max_num_faces=1)
+    estimator = HRVEstimator(fps=30)
+    frame_count = 0
+    bpm = 0.0
+    hrv = 0.0
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        results = face_mesh.process(rgb)
+        landmarks = []
+        if results.multi_face_landmarks:
+            landmarks = results.multi_face_landmarks[0].landmark
+            estimator.update(frame, landmarks)
+
+        if frame_count % 30 == 0:
+            data = estimator.compute()
+            bpm = data["bpm"]
+            hrv = data["hrv"]
+
+        text = "HRV no disponible"
+        if hrv > 0:
+            estado = "estresado" if hrv < 25 else "relajado"
+            text = f"BPM: {bpm:.1f} | HRV: {hrv:.1f} ms ({estado})"
+        cv2.putText(frame, text, (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 255, 0), 2)
+        cv2.imshow("HRV", frame)
+
+        if cv2.waitKey(1) & 0xFF == ord("q"):
+            break
+        frame_count += 1
+
+    face_mesh.close()
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/modules/hrv_rppg.py
+++ b/modules/hrv_rppg.py
@@ -1,0 +1,72 @@
+"""Real-time HRV and BPM estimation using rPPG.
+
+This module uses a simple green channel approach over the
+forehead region to compute heart rate variability (HRV)
+and beats per minute (BPM) from a video stream.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Sequence, Deque, Dict
+
+import cv2
+import numpy as np
+from scipy.signal import butter, filtfilt, find_peaks
+
+
+Point = Sequence[float]
+
+
+def _to_point(landmark: Any) -> Point:
+    """Converts a flexible landmark object to an ``(x, y)`` tuple."""
+    if hasattr(landmark, "x") and hasattr(landmark, "y"):
+        return float(landmark.x), float(landmark.y)
+    return float(landmark[0]), float(landmark[1])
+
+
+class HRVEstimator:
+    """Estimates BPM and HRV (RMSSD) from face video frames."""
+
+    def __init__(self, fps: int = 30) -> None:
+        self.fps = fps
+        self.signal: Deque[float] = deque(maxlen=300)
+
+    def update(self, frame: np.ndarray, landmarks: Sequence[Any]) -> None:
+        """Update the internal green channel signal with the forehead ROI."""
+        if len(landmarks) <= 10:
+            return
+        h, w = frame.shape[:2]
+        x, y = _to_point(landmarks[10])
+        cx, cy = int(x * w), int(y * h)
+        size = 10
+        x1, x2 = max(cx - size, 0), min(cx + size, w)
+        y1, y2 = max(cy - size, 0), min(cy + size, h)
+        roi = frame[y1:y2, x1:x2]
+        if roi.size == 0:
+            return
+        green = roi[:, :, 1].astype(np.float32)
+        mean_val = float(np.mean(green))
+        self.signal.append(mean_val)
+
+    def compute(self) -> Dict[str, float]:
+        """Compute BPM and HRV from the stored signal."""
+        if len(self.signal) < self.fps * 2:
+            return {"bpm": 0.0, "hrv": 0.0}
+
+        sig = np.array(self.signal, dtype=np.float32)
+        sig = sig - np.mean(sig)
+        fs = self.fps
+        b, a = butter(2, [0.7 / (fs / 2), 4 / (fs / 2)], btype="band")
+        filtered = filtfilt(b, a, sig)
+
+        peaks, _ = find_peaks(filtered, distance=int(fs * 0.25))
+        if len(peaks) < 2:
+            return {"bpm": 0.0, "hrv": 0.0}
+
+        rr = np.diff(peaks) / fs
+        bpm = 60.0 / np.mean(rr)
+        diff_rr = np.diff(rr)
+        rmssd = np.sqrt(np.mean(diff_rr ** 2)) * 1000.0  # ms
+        return {"bpm": float(bpm), "hrv": float(rmssd)}
+


### PR DESCRIPTION
## Summary
- implement a green-channel rPPG estimator in `modules/hrv_rppg.py`
- add example `main.py` that uses MediaPipe Face Mesh to show BPM and HRV

## Testing
- `python -m py_compile modules/hrv_rppg.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f59a206883259fd04efd896d5780