### PR TITLE
Improve BPM estimation using bandpass filtering

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,8 +11,8 @@ def main() -> None:
     face_mesh = mp.solutions.face_mesh.FaceMesh(static_image_mode=False, max_num_faces=1)
     estimator = HRVEstimator(fps=30)
     frame_count = 0
-    bpm = 0.0
-    hrv = 0.0
+    bpm = None
+    hrv = None
 
     while True:
         ret, frame = cap.read()
@@ -31,10 +31,12 @@ def main() -> None:
             bpm = data["bpm"]
             hrv = data["hrv"]
 
-        text = "HRV no disponible"
-        if hrv > 0:
+        text = "BPM: N/D"
+        if bpm is not None and hrv is not None:
             estado = "estresado" if hrv < 25 else "relajado"
             text = f"BPM: {bpm:.1f} | HRV: {hrv:.1f} ms ({estado})"
+        elif bpm is not None:
+            text = f"BPM: {bpm:.1f}"
         cv2.putText(frame, text, (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 255, 0), 2)
         cv2.imshow("HRV", frame)
 

--- a/posturazen-web/frontend/src/lib/pose/hrv.ts
+++ b/posturazen-web/frontend/src/lib/pose/hrv.ts
@@ -1,6 +1,35 @@
 export interface HRVResult {
-  bpm: number;
-  hrv: number;
+  bpm: number | null;
+  hrv: number | null;
+}
+
+function std(arr: number[]): number {
+  const m = arr.reduce((a, b) => a + b, 0) / arr.length;
+  const v = arr.reduce((a, b) => a + (b - m) * (b - m), 0) / arr.length;
+  return Math.sqrt(v);
+}
+
+function bandpass(sig: number[], fps: number): number[] {
+  // Butterworth coefficients for fps=30, 0.7-3.5 Hz band
+  const b = [0.06004382, 0, -0.12008764, 0, 0.06004382];
+  const a = [1, -3.02200416, 3.55111471, -1.95868597, 0.43749735];
+  const y = new Array(sig.length).fill(0);
+  for (let i = 0; i < sig.length; i++) {
+    y[i] = b[0] * sig[i];
+    if (i >= 1) y[i] += b[1] * sig[i - 1] - a[1] * y[i - 1];
+    if (i >= 2) y[i] += b[2] * sig[i - 2] - a[2] * y[i - 2];
+    if (i >= 3) y[i] += b[3] * sig[i - 3] - a[3] * y[i - 3];
+    if (i >= 4) y[i] += b[4] * sig[i - 4] - a[4] * y[i - 4];
+  }
+  const out = new Array(sig.length).fill(0);
+  for (let i = sig.length - 1; i >= 0; i--) {
+    out[i] = b[0] * y[i];
+    if (i + 1 < sig.length) out[i] += b[1] * y[i + 1] - a[1] * out[i + 1];
+    if (i + 2 < sig.length) out[i] += b[2] * y[i + 2] - a[2] * out[i + 2];
+    if (i + 3 < sig.length) out[i] += b[3] * y[i + 3] - a[3] * out[i + 3];
+    if (i + 4 < sig.length) out[i] += b[4] * y[i + 4] - a[4] * out[i + 4];
+  }
+  return out;
 }
 
 /**
@@ -42,27 +71,57 @@ export class HRVEstimator {
   }
 
   compute(): HRVResult {
-    if (this.signal.length < this.fps * 2) return { bpm: 0, hrv: 0 };
+    if (this.signal.length < this.fps * 2) return { bpm: null, hrv: null };
     const mean = this.signal.reduce((a, b) => a + b, 0) / this.signal.length;
     const centered = this.signal.map((v) => v - mean);
+
+    const filtered = bandpass(centered, this.fps);
+
+    const N = filtered.length;
+    const re: number[] = new Array(Math.floor(N / 2) + 1).fill(0);
+    const im: number[] = new Array(Math.floor(N / 2) + 1).fill(0);
+    for (let k = 0; k < re.length; k++) {
+      for (let n = 0; n < N; n++) {
+        const ang = (2 * Math.PI * k * n) / N;
+        re[k] += filtered[n] * Math.cos(ang);
+        im[k] -= filtered[n] * Math.sin(ang);
+      }
+    }
+    const freqs = re.map((_, i) => (i * this.fps) / N);
+    let peakIdx = -1;
+    let maxP = -Infinity;
+    for (let i = 0; i < freqs.length; i++) {
+      if (freqs[i] >= 0.7 && freqs[i] <= 3.5) {
+        const p = re[i] * re[i] + im[i] * im[i];
+        if (p > maxP) {
+          maxP = p;
+          peakIdx = i;
+        }
+      }
+    }
+    if (peakIdx === -1) return { bpm: null, hrv: null };
+    const bpm = freqs[peakIdx] * 60;
+
     const peaks: number[] = [];
-    for (let i = 1; i < centered.length - 1; i++) {
-      if (centered[i] > centered[i - 1] && centered[i] > centered[i + 1]) {
+    const thresh = std(filtered) * 0.5;
+    for (let i = 1; i < filtered.length - 1; i++) {
+      if (
+        filtered[i] > filtered[i - 1] &&
+        filtered[i] > filtered[i + 1] &&
+        filtered[i] > thresh
+      ) {
         peaks.push(i);
       }
     }
-    if (peaks.length < 2) return { bpm: 0, hrv: 0 };
+    if (peaks.length < 3) return { bpm, hrv: null };
     const rr: number[] = [];
     for (let i = 1; i < peaks.length; i++) {
       rr.push((peaks[i] - peaks[i - 1]) / this.fps);
     }
-    const rrMean = rr.reduce((a, b) => a + b, 0) / rr.length;
-    const bpm = 60 / rrMean;
+    if (rr.length < 2) return { bpm, hrv: null };
     const diff: number[] = [];
-    for (let i = 1; i < rr.length; i++) {
-      diff.push(rr[i] - rr[i - 1]);
-    }
-    const rmssd = Math.sqrt(diff.reduce((a, b) => a + b * b, 0) / (diff.length || 1)) * 1000;
+    for (let i = 1; i < rr.length; i++) diff.push(rr[i] - rr[i - 1]);
+    const rmssd = Math.sqrt(diff.reduce((a, b) => a + b * b, 0) / diff.length) * 1000;
     return { bpm, hrv: rmssd };
   }
 

--- a/posturazen-web/frontend/src/routes/+page.svelte
+++ b/posturazen-web/frontend/src/routes/+page.svelte
@@ -28,8 +28,8 @@
   let visibility = 0;
   let posture = '';
 
-  let bpm = 0;
-  let hrvValue = 0;
+  let bpm: number | null = null;
+  let hrvValue: number | null = null;
   let hrvEstimator: HRVEstimator;
 
   let badStart: number | null = null;
@@ -158,8 +158,8 @@
         <p>Ángulo hombros-cadera: {hipAngle}°</p>
         <p>Visibilidad promedio: {visibility}%</p>
         <p>Estado: {posture}</p>
-        <p>Frecuencia cardiaca (BPM): {bpm ? bpm.toFixed(1) : 'N/A'}</p>
-        <p>HRV estimado: {hrvValue ? hrvValue.toFixed(1) + ' ms' : 'N/A'}</p>
+        <p>Frecuencia cardiaca (BPM): {bpm === null ? 'N/D' : bpm.toFixed(1)}</p>
+        <p>HRV estimado: {hrvValue === null ? 'N/D' : hrvValue.toFixed(1) + ' ms'}</p>
         {#if showWarning}
           <p class="alert">⚠️ Ajusta tu postura para evitar fatiga</p>
         {/if}


### PR DESCRIPTION
## Summary
- correct BPM calculation with band‑pass filter and dominant frequency
- return `None` when BPM/HRV cannot be estimated
- update example UI text to display `N/D` when BPM is unavailable
- implement matching logic in the web frontend

## Testing
- `python3 -m py_compile main.py modules/hrv_rppg.py`
- `npm install` *(fails: 404 for mediapipe packages)*

------
https://chatgpt.com/codex/tasks/task_e_68840067341c832592e58b1c3dbdd544