### PR TITLE
Add frontend setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,20 @@ python -m PosturaZen.main
 Este comando debe ejecutarse desde la raíz del repositorio y pone en marcha el
 sistema de detección y corrección de postura.
 
+## Frontend
+
+Para ejecutar la interfaz web desarrollada con Svelte es necesario
+instalar las dependencias de Node.js. Desde la raíz del repositorio:
+
+```bash
+cd posturazen-web/frontend
+npm install
+npm run dev
+```
+
+El paso de `npm install` es importante para que paquetes como
+`chart.js` estén disponibles y el servidor de desarrollo funcione
+correctamente.
+
 Autor
 Ricardo A. Romero – @Adal612Git


### PR DESCRIPTION
## Summary
- document how to run the Svelte frontend and ensure dependencies like chart.js are installed

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6884432e11988325913f39600dcdd231